### PR TITLE
upgrade versioning logic for dependabot

### DIFF
--- a/lib/sage_pay/version.rb
+++ b/lib/sage_pay/version.rb
@@ -1,3 +1,6 @@
 module SagePay
-  VERSION = '1.0.2'
+  base = '1.0.2'
+
+  # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
+  VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"
 end

--- a/lib/sage_pay/version.rb
+++ b/lib/sage_pay/version.rb
@@ -1,5 +1,5 @@
 module SagePay
-  base = '1.0.2'
+  base = '1.0.3'
 
   # SB-specific versioning "algorithm" to accommodate BNW/Jenkins/gemstash
   VERSION = (pre = ENV.fetch('GEM_PRE_RELEASE', '')).empty? ? base : "#{base}.#{pre}"

--- a/sage_pay.gemspec
+++ b/sage_pay.gemspec
@@ -7,14 +7,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.rubygems_version = '1.3.6'
 
-  gem_version = if ENV['GEM_PRE_RELEASE'].nil? || ENV['GEM_PRE_RELEASE'].empty?
-                  SagePay::VERSION
-                else
-                  "#{SagePay::VERSION}.#{ENV['GEM_PRE_RELEASE']}"
-                end
-
   s.name              = 'sage_pay'
-  s.version           = gem_version
+  s.version           = SagePay::VERSION
   s.date              = '2012-07-21'
   s.rubyforge_project = 'sage_pay'
 


### PR DESCRIPTION
upgrade gemstash versioning logic so that dependabot can automatically
manage versions of dependencies in the gemspec

dependabot is used to create automatic PRs for security vulnerabilities